### PR TITLE
fix(interface): sync theme dropdown with library state on init

### DIFF
--- a/Addons/InterfaceManager.lua
+++ b/Addons/InterfaceManager.lua
@@ -76,7 +76,7 @@ local InterfaceManager = {} do
 			end
 		})
 
-        InterfaceTheme:SetValue(Settings.Theme)
+        InterfaceTheme:SetValue(Library.Theme)
 	
 		if Library.UseAcrylic then
 			section:AddToggle("AcrylicToggle", {


### PR DESCRIPTION
Currently, InterfaceManager hardcodes the theme to "Dark" on startup, ignoring the theme set in CreateWindow. This change makes the dropdown check Library.Theme instead, so it respects the developer's choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the theme dropdown in Interface settings to correctly display the currently active theme.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->